### PR TITLE
_cvtProperties undefined

### DIFF
--- a/packages/convict/src/main.js
+++ b/packages/convict/src/main.js
@@ -361,7 +361,11 @@ function overlay(from, to, schema) {
       if (!isObj(to[k])) {
         to[k] = {}
       }
-      overlay(from[k], to[k], schema._cvtProperties[k])
+      let overlaySchema;
+      if (schema.hasOwnProperty('_cvtProperties'))
+        overlaySchema= schema._cvtProperties[k]
+      else overlaySchema= schema.default[k]
+      overlay(from[k], to[k], overlaySchema)
     }
   })
 }


### PR DESCRIPTION
_cvtProperties do not exist on final path of schema

The default value for FOO.BAR.BAZ is stored in `_schema._cvtProperties` at: FOO._cvtProperties.BAR._cvtProperties.BAZ.default

TypeError: Cannot read properties of undefined (reading <k>)
    at node_modules\convict\src\main.js:371:52
    at Array.forEach (<anonymous>)
    at overlay (node_modules\convict\src\main.js:363:21)
    at node_modules\convict\src\main.js:371:7
    at Array.forEach (<anonymous>)
    at overlay (node_modules\convict\src\main.js:363:21)
    at node_modules\convict\src\main.js:371:7
    at Array.forEach (<anonymous>)
    at overlay (node_modules\convict\src\main.js:363:21)
    at node_modules\convict\src\main.js:609:11